### PR TITLE
An issue was being caused where x2, y1 or y2 was being set to None du…

### DIFF
--- a/optunity/metrics.py
+++ b/optunity/metrics.py
@@ -149,6 +149,12 @@ def auc(curve):
         x2, y2 = curve[i + 1]
         if y1 is None:
             y1 = 0.0
+	if y2 is None:
+	    y2 = 0.0
+	if x1 is None:
+	    x1 = 0.0
+	if x2 is None:
+	    x2 = 0.0
         area += float(min(y1, y2)) * float(x2 - x1) + math.fabs(float(y2 - y1)) * float(x2 - x1) / 2
 
     return area


### PR DESCRIPTION
An issue was being caused where x2, y1 or y2 was being set to None during calculation of roc_auc. When I saw the line where x1 being None is reinterpreted as 0.0, I added corresponding lines for the other variables as well. I am not sure if this is the correct interpretation as I haven't taken the time to fully explore what a None value really means. If incorrect, it could mean that my auc is being incorrectly calculated.