### PR TITLE
Quick fix for CallLog.to_dict() KeyErrors

### DIFF
--- a/optunity/functions.py
+++ b/optunity/functions.py
@@ -225,13 +225,13 @@ class CallLog(object):
 
         """
         if self.data:
-            args = dict([(k, []) for k in list(self.keys())[0].keys()])
+            args = collections.defaultdict(list)
             values = []
             for k, v in self.data.items():
                 for key, value in k:
                     args[key].append(value)
                 values.append(v)
-            return {'args': args, 'values': values}
+            return {'args': dict(args), 'values': values}
         else:
             return {'args': {}, 'values': []}
 


### PR DESCRIPTION
I have not taken the time to really understand what `CallLog` is trying to do, but this seems to fix the crashes people are seeing (e.g., #65, #66).  

The design of `CallLog` seems a bit complicated; if it's just a map of function arguments to return values, you might consider as keys a sorted tuple of key-value pairs, or a (normalized) serialization such as JSON or pickle.
