### PR TITLE
Fix for recall and precision metrics

### DIFF
--- a/optunity/metrics.py
+++ b/optunity/metrics.py
@@ -336,7 +336,12 @@ def fbeta(y, yhat, beta, positive=True):
     """
     bsq = beta ** 2
     TP, FP, _, FN = contingency_table(y, yhat, positive)
-    return float(1 + bsq) * TP / ((1 + bsq) * TP + bsq * FN + FP)
+
+    if TP == 0 and FP == 0 and FN == 0:
+        fbeta = 0.0
+    else:
+        fbeta = float(1 + bsq) * TP / ((1 + bsq) * TP + bsq * FN + FP)
+    return fbeta
 
 def precision(y, yhat, positive=True):
     """Returns the precision (higher is better).

--- a/optunity/metrics.py
+++ b/optunity/metrics.py
@@ -348,8 +348,8 @@ def precision(y, yhat, positive=True):
     :returns: number of true positive predictions / number of positive predictions
 
     """
-    TP, FP, _, _ = contingency_table(y, yhat, positive)
-    return _precision(TP, FP)
+    table = contingency_table(y, yhat, positive)
+    return _precision(table)
 
 def recall(y, yhat, positive=True):
     """Returns the recall (higher is better).
@@ -361,8 +361,8 @@ def recall(y, yhat, positive=True):
     :returns: number of true positive predictions / number of true positives
 
     """
-    TP, _, _, FN = contingency_table(y, yhat, positive)
-    return _recall(TP, FN)
+    table = contingency_table(y, yhat, positive)
+    return _recall(table)
 
 def npv(y, yhat, positive=True):
     """Returns the negative predictive value (higher is better).


### PR DESCRIPTION
Recall and precision passed TP, FP and FN directly instead of the contingency table, causing errors when calculating these metrics.